### PR TITLE
TCA Tutorial / Your first feature 완료 & 회고

### DIFF
--- a/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
+++ b/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		71ACF9A72BECCC0000AF7E0A /* TCA_PracticeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ACF9A62BECCC0000AF7E0A /* TCA_PracticeUITests.swift */; };
 		71ACF9A92BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ACF9A82BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift */; };
 		71ACF9B72BECCD8C00AF7E0A /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 71ACF9B62BECCD8C00AF7E0A /* ComposableArchitecture */; };
+		C6F491FF2BED0BC5007458BF /* CounterFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F491FE2BED0BC5007458BF /* CounterFeature.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		71ACF9A22BECCC0000AF7E0A /* TCA_PracticeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TCA_PracticeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		71ACF9A62BECCC0000AF7E0A /* TCA_PracticeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCA_PracticeUITests.swift; sourceTree = "<group>"; };
 		71ACF9A82BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCA_PracticeUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		C6F491FE2BED0BC5007458BF /* CounterFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterFeature.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 		C6F491FB2BED0A30007458BF /* YourFirstFeature */ = {
 			isa = PBXGroup;
 			children = (
+				C6F491FE2BED0BC5007458BF /* CounterFeature.swift */,
 			);
 			path = YourFirstFeature;
 			sourceTree = "<group>";
@@ -273,6 +276,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6F491FF2BED0BC5007458BF /* CounterFeature.swift in Sources */,
 				71ACF98E2BECCBFF00AF7E0A /* ContentView.swift in Sources */,
 				71ACF98C2BECCBFF00AF7E0A /* TCA_PracticeApp.swift in Sources */,
 			);

--- a/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
+++ b/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		71ACF9A72BECCC0000AF7E0A /* TCA_PracticeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ACF9A62BECCC0000AF7E0A /* TCA_PracticeUITests.swift */; };
 		71ACF9A92BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ACF9A82BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift */; };
 		71ACF9B72BECCD8C00AF7E0A /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 71ACF9B62BECCD8C00AF7E0A /* ComposableArchitecture */; };
+		C62B6C1D2BED0F46005AD514 /* YourFirstFeatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62B6C1C2BED0F46005AD514 /* YourFirstFeatureView.swift */; };
 		C6F491FF2BED0BC5007458BF /* CounterFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F491FE2BED0BC5007458BF /* CounterFeature.swift */; };
 /* End PBXBuildFile section */
 
@@ -46,6 +47,7 @@
 		71ACF9A22BECCC0000AF7E0A /* TCA_PracticeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TCA_PracticeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		71ACF9A62BECCC0000AF7E0A /* TCA_PracticeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCA_PracticeUITests.swift; sourceTree = "<group>"; };
 		71ACF9A82BECCC0000AF7E0A /* TCA_PracticeUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCA_PracticeUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		C62B6C1C2BED0F46005AD514 /* YourFirstFeatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourFirstFeatureView.swift; sourceTree = "<group>"; };
 		C6F491FE2BED0BC5007458BF /* CounterFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterFeature.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -136,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				C6F491FE2BED0BC5007458BF /* CounterFeature.swift */,
+				C62B6C1C2BED0F46005AD514 /* YourFirstFeatureView.swift */,
 			);
 			path = YourFirstFeature;
 			sourceTree = "<group>";
@@ -279,6 +282,7 @@
 				C6F491FF2BED0BC5007458BF /* CounterFeature.swift in Sources */,
 				71ACF98E2BECCBFF00AF7E0A /* ContentView.swift in Sources */,
 				71ACF98C2BECCBFF00AF7E0A /* TCA_PracticeApp.swift in Sources */,
+				C62B6C1D2BED0F46005AD514 /* YourFirstFeatureView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
+++ b/TCA_Practice/TCA_Practice.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -424,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -450,6 +450,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -479,6 +480,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -501,7 +503,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = SD8J3B58T9;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "test.TCA-PracticeTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -521,7 +523,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = SD8J3B58T9;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "test.TCA-PracticeTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TCA_Practice/TCA_Practice/ContentView.swift
+++ b/TCA_Practice/TCA_Practice/ContentView.swift
@@ -12,9 +12,9 @@ struct ContentView: View {
         NavigationView {
             List {
                 Section {
-                    NavigationLink(destination: YourFirstFeatureView()) {
-                        Text("Your first feature")
-                    }
+//                    NavigationLink(destination: YourFirstFeatureView()) {
+//                        Text("Your first feature")
+//                    }
                 } header: {
                     Text("TCA_Tutorial")
                         .font(.title3)

--- a/TCA_Practice/TCA_Practice/ContentView.swift
+++ b/TCA_Practice/TCA_Practice/ContentView.swift
@@ -12,9 +12,11 @@ struct ContentView: View {
         NavigationView {
             List {
                 Section {
-//                    NavigationLink(destination: YourFirstFeatureView()) {
-//                        Text("Your first feature")
-//                    }
+                    NavigationLink(destination: YourFirstFeatureView(
+                        store: TCA_PracticeApp.counterStore
+                    )) {
+                        Text("Your first feature")
+                    }
                 } header: {
                     Text("TCA_Tutorial")
                         .font(.title3)

--- a/TCA_Practice/TCA_Practice/ContentView.swift
+++ b/TCA_Practice/TCA_Practice/ContentView.swift
@@ -9,13 +9,20 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationView {
+            List {
+                Section {
+                    NavigationLink(destination: YourFirstFeatureView()) {
+                        Text("Your first feature")
+                    }
+                } header: {
+                    Text("TCA_Tutorial")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
+            }
+            .navigationTitle("TCA_Practice")
         }
-        .padding()
     }
 }
 

--- a/TCA_Practice/TCA_Practice/TCA_PracticeApp.swift
+++ b/TCA_Practice/TCA_Practice/TCA_PracticeApp.swift
@@ -6,9 +6,14 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 
 @main
 struct TCA_PracticeApp: App {
+    static let counterStore = Store(initialState: CounterFeature.State()) {
+        CounterFeature()
+            ._printChanges()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/CounterFeature.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/CounterFeature.swift
@@ -1,0 +1,34 @@
+//
+//  CounterFeature.swift
+//  TCA_Practice
+//
+//  Created by Doogie on 5/9/24.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct CounterFeature {
+    @ObservableState
+    struct State {
+        var count = 0
+    }
+    
+    enum Action {
+        case decrementButtonTapped
+        case incrementButtonTapped
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .decrementButtonTapped:
+                state.count -= 1
+                return .none
+            case .incrementButtonTapped:
+                state.count += 1
+                return .none
+            }
+        }
+    }
+}

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/CounterFeature.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/CounterFeature.swift
@@ -7,14 +7,12 @@
 
 import ComposableArchitecture
 
-@Reducer
-struct CounterFeature {
-    @ObservableState
-    struct State {
+struct CounterFeature: Reducer {
+    struct State: Equatable {
         var count = 0
     }
     
-    enum Action {
+    enum Action: Equatable {
         case decrementButtonTapped
         case incrementButtonTapped
     }

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
@@ -10,24 +10,28 @@ import ComposableArchitecture
 
 struct YourFirstFeatureView: View {
     let store: StoreOf<CounterFeature>
+    @ObservedObject var viewStore: ViewStoreOf<CounterFeature>
+    
+    init(store: StoreOf<CounterFeature>) {
+        self.store = store
+        self.viewStore = ViewStore(store, observe: { $0 })
+    }
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack {
-                Text("\(viewStore.count)")
-                    .padding()
-                    .font(.largeTitle)
-                    .frame(minWidth: 50)
-                    .background(.black.opacity(0.1))
-                    .cornerRadius(10)
-                
-                HStack {
-                    counterButton(text: "-") {
-                        viewStore.send(.decrementButtonTapped)
-                    }
-                    counterButton(text: "+") {
-                        viewStore.send(.incrementButtonTapped)
-                    }
+        VStack {
+            Text("\(viewStore.count)")
+                .padding()
+                .font(.largeTitle)
+                .frame(minWidth: 50)
+                .background(.black.opacity(0.1))
+                .cornerRadius(10)
+            
+            HStack {
+                counterButton(text: "-") {
+                    viewStore.send(.decrementButtonTapped)
+                }
+                counterButton(text: "+") {
+                    viewStore.send(.incrementButtonTapped)
                 }
             }
         }

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
@@ -1,0 +1,18 @@
+//
+//  YourFirstFeatureView.swift
+//  TCA_Practice
+//
+//  Created by Doogie on 5/9/24.
+//
+
+import SwiftUI
+
+struct YourFirstFeatureView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    YourFirstFeatureView()
+}

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
@@ -12,20 +12,22 @@ struct YourFirstFeatureView: View {
     let store: StoreOf<CounterFeature>
     
     var body: some View {
-        VStack {
-            Text("\(store.count)")
-                .padding()
-                .font(.largeTitle)
-                .frame(minWidth: 50)
-                .background(.black.opacity(0.1))
-                .cornerRadius(10)
-            
-            HStack {
-                counterButton(text: "-") {
-                    store.send(.decrementButtonTapped)
-                }
-                counterButton(text: "+") {
-                    store.send(.incrementButtonTapped)
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            VStack {
+                Text("\(viewStore.count)")
+                    .padding()
+                    .font(.largeTitle)
+                    .frame(minWidth: 50)
+                    .background(.black.opacity(0.1))
+                    .cornerRadius(10)
+                
+                HStack {
+                    counterButton(text: "-") {
+                        viewStore.send(.decrementButtonTapped)
+                    }
+                    counterButton(text: "+") {
+                        viewStore.send(.incrementButtonTapped)
+                    }
                 }
             }
         }

--- a/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
+++ b/TCA_Practice/TCA_Practice/YourFirstFeature/YourFirstFeatureView.swift
@@ -6,13 +6,48 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 
 struct YourFirstFeatureView: View {
+    let store: StoreOf<CounterFeature>
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("\(store.count)")
+                .padding()
+                .font(.largeTitle)
+                .frame(minWidth: 50)
+                .background(.black.opacity(0.1))
+                .cornerRadius(10)
+            
+            HStack {
+                counterButton(text: "-") {
+                    store.send(.decrementButtonTapped)
+                }
+                counterButton(text: "+") {
+                    store.send(.incrementButtonTapped)
+                }
+            }
+        }
+    }
+    
+    private func counterButton(text: String, action: @escaping () -> Void) -> some View {
+        Button(action: {
+            action()
+        }, label: {
+            Text(text)
+                .padding()
+                .font(.largeTitle)
+                .frame(width: 50)
+                .background(.black.opacity(0.1))
+                .cornerRadius(10)
+        })
     }
 }
 
 #Preview {
-    YourFirstFeatureView()
+    YourFirstFeatureView(store: Store(initialState: CounterFeature.State(),
+                                      reducer: {
+        CounterFeature()
+    }))
 }


### PR DESCRIPTION
https://dev-doogie.tistory.com/22

위 블로그 글 처럼 대략적인 TCA의 흐름에 대해 공부하고 튜토리얼을 시작했으나...

튜토리얼도 만들어진지 좀 되었는지 문제가 좀 있었어서 아래 내용에 정리해보려 한다.

## Trouble Shooting
### Traking 오류
![Pasted Graphic](https://github.com/doogie97/TCA_Practice/assets/82325822/24c654ed-4e8e-42e5-84d9-8ef8e5bcafd6)
튜토리얼 대로 구현하고 시뮬레이터에서 실행해보니 위와 같은 무서운(ㄷㄷ...) 에러가 콘솔에 찍혔다.

그래서 에러에서 알려준대로 "WithPerceptionTracking" 로 뷰를 감쌌더니 해당 에러는 더 이상 뜨지 않았지만...
![image](https://github.com/doogie97/TCA_Practice/assets/82325822/038f19e7-78ae-4c53-865c-fbd8147f8b8f)
예...?? deprecated요? 그럼 저는 어쩌라고.. 라고 생각하던 찰나

오전 출근길에 본 수많은 블로그 글 중 희미하게 스쳐지나가는 내용이 'WithViewStore 감쌌던 것 같은데..." 하는 생각이 들어 찾아봤다

View에서 관찰 가능한 Store가 ViewStore라고 한다
그러면 애초에 Reducer를 만들 때 @ObservableState 키워드를 적어줄 필요가 없어질 것이며 아래와 같이 새로 구현했다.
```
       WithViewStore(self.store, observe: { $0 }) { viewStore in
//뷰 구성 코드
        }
```
이렇게 하니 에러도 없이 정상 작동 되었다


하지만 ViewStore에 대해 더 찾아본 결과 아래와 같이 @ObservedObject var 로 ViewStore를 만들어두면 결과는 같은데 뷰를 한 번 더 감싸지 않을 뿐더러 코드더 한결 더 깔끔하게 작성 할 수 있다

```
 let store: StoreOf<CounterFeature>
    @ObservedObject var viewStore: ViewStoreOf<CounterFeature>
    
    init(store: StoreOf<CounterFeature>) {
        self.store = store
        self.viewStore = ViewStore(store, observe: { $0 })
    }
    
    var body: some View {
        VStack {
            Text("\(viewStore.count)")
//이하 생략
```